### PR TITLE
更新创建文件夹错误信息

### DIFF
--- a/unyaffs.c
+++ b/unyaffs.c
@@ -523,7 +523,7 @@ void process_chunk(void) {
 		case YAFFS_OBJECT_TYPE_DIRECTORY:
 			if (pt->t.objectId != YAFFS_OBJECTID_ROOT &&
 			    mkdir(obj->path_name, oh.yst_mode & STD_PERMS) < 0)
-					prt_err(1, errno, "Can't create directory %s", obj->path_name);
+					prt_err(0, errno, "Can't create directory %s", obj->path_name);
 			safe_lchown(obj->path_name, oh.yst_uid, oh.yst_gid);
 			if ((pt->t.objectId == YAFFS_OBJECTID_ROOT ||
 			     (oh.yst_mode & EXTRA_PERMS) != 0) &&


### PR DESCRIPTION
fix：发现存在这样的情况，可能imag里有重复的文件夹创建，此处就会一直报错文件夹创建失败而不继续进行解压
修改为此种错误不终止，继续解压